### PR TITLE
BB-9 removed deprecated vars and profiles from launchsettings.json

### DIFF
--- a/src/Core/Properties/launchSettings.json
+++ b/src/Core/Properties/launchSettings.json
@@ -4,24 +4,7 @@
       "commandName": "Project",
       "environmentVariables": {
         "APIKEY": "key",
-        "GUILDID": "id",
-        "BUILDNEWCOMMANDS": "deprecated",
-        "VERSION": "deprecated",
-        "RELEASESTREAM": "deprecated"
-      }
-    },
-    "WSL": {
-      "commandName": "WSL2",
-      "distributionName": ""
-    },
-    "Docker": {
-      "commandName": "Docker",
-      "environmentVariables": {
-        "APIKEY": "key",
-        "GUILDID": "id",
-        "BUILDNEWCOMMANDS": "deprecated",
-        "VERSION": "deprecated",
-        "RELEASESTREAM": "deprecated"
+        "GUILDID": "id"
       }
     }
   }


### PR DESCRIPTION
The only default launch profile now is for an exe with the env vars APIKEY, and GUILDID. 

More profiles can be added by devs locally if they want, but this should be the only default launch profile